### PR TITLE
chore: rename `jwt_pub_key` to `certificate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Initialization requires 6 parameters, which are all string type:
 | endpoint        | Yes  | Casdoor Server Url, such as `http://localhost:8000` |
 | client_id       | Yes  | Client ID for the Casdoor application               |
 | client_secret   | Yes  | Client secret for the Casdoor application           |
-| jwt_pub_key     | Yes  | The public key for the Casdoor application's cert   |
+| certificate     | Yes  | x509 certificate content of Application.cert        |
 | org_name        | Yes  | The name for the Casdoor organization               |
 | app_name        | No   | The name for the Casdoor application                |
 

--- a/src/entity/config.rs
+++ b/src/entity/config.rs
@@ -21,7 +21,7 @@ pub struct CasdoorConfig {
     pub(crate) endpoint: String,
     pub(crate) client_id: String,
     pub(crate) client_secret: String,
-    pub(crate) jwt_pub_key: String,
+    pub(crate) certificate: String,
     pub(crate) org_name: String,
     pub(crate) app_name: Option<String>,
 }
@@ -33,7 +33,7 @@ impl CasdoorConfig {
         endpoint: String,
         client_id: String,
         client_secret: String,
-        jwt_pub_key: String,
+        certificate: String,
         org_name: String,
         app_name: Option<String>,
     ) -> Self {
@@ -41,7 +41,7 @@ impl CasdoorConfig {
             endpoint,
             client_id,
             client_secret,
-            jwt_pub_key: Self::replace_cert_to_pub_key(jwt_pub_key),
+            certificate: Self::replace_cert_to_pub_key(certificate),
             org_name,
             app_name,
         }
@@ -58,12 +58,12 @@ impl CasdoorConfig {
         let mut conf: CasdoorConfig = toml::from_str(&content)?;
 
         // need to convert the certificate to pem format
-        conf.jwt_pub_key = Self::replace_cert_to_pub_key(conf.jwt_pub_key);
+        conf.certificate = Self::replace_cert_to_pub_key(conf.certificate);
 
         Ok(conf)
     }
 
-    fn replace_cert_to_pub_key(jwt_pub_key: String) -> String {
-        jwt_pub_key.replace("CERTIFICATE", "PUBLIC KEY")
+    fn replace_cert_to_pub_key(certificate: String) -> String {
+        certificate.replace("CERTIFICATE", "PUBLIC KEY")
     }
 }

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -54,7 +54,7 @@ impl<'a> AuthService<'a> {
     ) -> Result<CasdoorUser, Box<dyn std::error::Error>> {
         let res = jsonwebtoken::decode::<CasdoorUser>(
             &token,
-            &DecodingKey::from_rsa_pem(self.config.jwt_pub_key.as_bytes())?,
+            &DecodingKey::from_rsa_pem(self.config.certificate.as_bytes())?,
             &Validation::new(Algorithm::RS256),
         )?;
 


### PR DESCRIPTION
see: https://github.com/casdoor/casdoor/issues/585