### PR TITLE
fix: attempted fix "unknown target triple" error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,4 @@ iron = "0.6.1"
 router = "0.6.0"
 urlencoding = "2.1.0"
 url = "2.2.2"
-hyper = {version = "0.14.19", features = ["server"]}
+hyper = {version = "0.14.26", features = ["server"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,13 @@ urlencoding = "2.1.0"
 oauth2 = "4.1"
 toml = "0.5.9"
 serde_derive = "1.0"
-windows-targets = "0.48.0"
+windows-targets = {version = "0.48.1", features = [
+    "Data_Xml_Dom",
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Threading",
+    "Win32_UI_WindowsAndMessaging",
+]}
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,16 @@ urlencoding = "2.1.0"
 oauth2 = "4.1"
 toml = "0.5.9"
 serde_derive = "1.0"
-windows-targets = {version = "0.48.1", features = [
+
+[dependencies.windows]
+version = "0.48"
+features = [
     "Data_Xml_Dom",
     "Win32_Foundation",
     "Win32_Security",
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
-]}
+]
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ jsonwebtoken = "8"
 http = "0.2"
 urlencoding = "2.1.0"
 oauth2 = "4.1"
-toml = "0.5.9"
+toml = "0.7.4"
 serde_derive = "1.0"
 
 [dependencies.windows]


### PR DESCRIPTION
As per windows-targets crate documentation I added a few features flags along with the new version of 0.48.1 instead of 0.48.0.

Fix: https://github.com/casdoor/casdoor-rust-sdk/issues/32